### PR TITLE
Add showSurveyWithEvent method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0 (2022-12-22)
+
+* Add showSurveyWithEvent method
+
 ## 0.0.2 (2022-07-26)
 
 * Improved docuemantation and added plugin documentation links.

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -81,6 +81,9 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       wootric?.setLanguageCode(languageCode)
     } else if (call.method.equals("showWootricSurvey")) {
       wootric?.survey()
+    } else if (call.method.equals("showWootricSurveyWithEvent")) {
+      val eventName: String? = call.argument("eventName")
+      wootric?.survey(eventName)
     } else {
       result.notImplemented()
     }

--- a/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
@@ -108,6 +108,15 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
                     Wootric.showSurvey(in: viewController)
                 }
 
+            case "showWootricSurveyWithEvent":
+                if let window = UIApplication.shared.delegate?.window {
+                    if let arguments = call.arguments as? [String: Any] {
+                        let eventName = arguments["eventName"] as? String
+                        let viewController = window?.rootViewController
+                        Wootric.showSurvey(in: viewController, event: eventName)
+                    }
+                }
+
             default:
                 result(FlutterMethodNotImplemented)
             }

--- a/lib/wootricsdk_flutter.dart
+++ b/lib/wootricsdk_flutter.dart
@@ -106,4 +106,9 @@ class WootricsdkFlutter {
   static showSurvey() {
     WootricsdkFlutterPlatform.instance.showSurvey();
   }
+
+  /// Display Wootric survey driven by configured settings and event name.
+  static showSurveyWithEvent(String eventName) {
+    WootricsdkFlutterPlatform.instance.showSurveyWithEvent(eventName);
+  }
 }

--- a/lib/wootricsdk_flutter_method_channel.dart
+++ b/lib/wootricsdk_flutter_method_channel.dart
@@ -154,4 +154,11 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
   showSurvey() {
     methodChannel.invokeMethod('showWootricSurvey');
   }
+
+  @override
+  showSurveyWithEvent(String eventName) {
+    methodChannel.invokeMethod('showWootricSurveyWithEvent', {
+      'eventName': eventName
+    });
+  }
 }

--- a/lib/wootricsdk_flutter_platform_interface.dart
+++ b/lib/wootricsdk_flutter_platform_interface.dart
@@ -122,4 +122,9 @@ abstract class WootricsdkFlutterPlatform extends PlatformInterface {
 
   }
 
+  /// Display Wootric survey driven by configured settings and event name.
+  showSurveyWithEvent(String eventName) {
+
+  }
+
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wootricsdk_flutter
 description: This is an official Wootric SDK Wrapper for Flutter. To use this plugin you need minimum a free Wootric Account with valid ClientId and AccountToken. You can visit wootric website for more details. Here is the official documentation for wootric - http://docs.wootric.com/
-version: 0.0.2
+version: 0.1.0
 homepage: https://inmoment.com/wootric/
 repository: https://github.com/Wootric/WootricSDK-flutter/
 issue_tracker: https://github.com/Wootric/WootricSDK-flutter/issues


### PR DESCRIPTION
Add `showSurveyWithEvent` method to support event based sampling.

## Test

1. Checkout this branch
2. Create a new flutter project and add this project as a dependency in your `pubspec.yaml`:

```
dependencies:
  flutter:
    sdk: flutter
...
  wootricsdk_flutter:
    path: /Users/username/path/to/WootricSDK-flutter
```

3. Use the new method

```dart
    WootricsdkFlutter.configure(
      clientId: "YOUR_CLIENT_ID",
      accountToken: "YOUR_ACCOUNT_TOKEN",
    );
    WootricsdkFlutter.setEndUserEmail('email@test.com');
    WootricsdkFlutter.showSurveyWithEvent("event_name");
  }

```

4. Test both iOS and Android