### PR TITLE
Add color customization (smartphones)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0 (2023-01-04)
+
+* Add color customization methods
+
 ## 0.1.0 (2022-12-22)
 
 * Add showSurveyWithEvent method
@@ -5,7 +9,6 @@
 ## 0.0.2 (2022-07-26)
 
 * Improved docuemantation and added plugin documentation links.
-
 
 ## 0.0.1 (2022-07-19)
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.wootric:wootric-sdk-android:2.21.1'
+    implementation 'com.wootric:wootric-sdk-android:2.21.2'
 }

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -1,6 +1,7 @@
 package com.inmoment.wootricsdk_flutter
 
 import android.app.Activity
+import android.graphics.Color
 import androidx.annotation.NonNull
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -79,6 +80,22 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     } else if (call.method.equals("setLanguageCode")) {
       val languageCode: String? = call.argument("languageCode")
       wootric?.setLanguageCode(languageCode)
+    } else if (call.method.equals("setSliderColor")) {
+      val hexColor: String? = call.argument("color")
+      val color: Int = Color.parseColor(hexColor)
+      wootric?.setScoreColor(color)
+    } else if (call.method.equals("setSendButtonBackgroundColor")) {
+      val hexColor: String? = call.argument("color")
+      val color: Int = Color.parseColor(hexColor)
+      wootric?.setSurveyColor(color)
+    } else if (call.method.equals("setThankYouButtonBackgroundColor")) {
+      val hexColor: String? = call.argument("color")
+      val color: Int = Color.parseColor(hexColor)
+      wootric?.setThankYouButtonBackgroundColor(color)
+    } else if (call.method.equals("setSocialSharingColor")) {
+      val hexColor: String? = call.argument("color")
+      val color: Int = Color.parseColor(hexColor)
+      wootric?.setSocialSharingColor(color)
     } else if (call.method.equals("showWootricSurvey")) {
       wootric?.survey()
     } else if (call.method.equals("showWootricSurveyWithEvent")) {

--- a/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
@@ -102,6 +102,38 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
                     Wootric.setCustomLanguage(languageCode)
                 }
 
+            case "setSliderColor":
+                if let arguments = call.arguments as? [String: Any],
+                   let hexColor = arguments["color"] as? String {
+                    if let color = convertHEXtoUIColor(hexColor) {
+                        Wootric.setSliderColor(color)
+                    }
+                }
+
+            case "setSendButtonBackgroundColor":
+                if let arguments = call.arguments as? [String: Any],
+                   let hexColor = arguments["color"] as? String {
+                    if let color = convertHEXtoUIColor(hexColor) {
+                        Wootric.setSendButtonBackgroundColor(color)
+                    }
+                }
+
+            case "setThankYouButtonBackgroundColor":
+                if let arguments = call.arguments as? [String: Any],
+                   let hexColor = arguments["color"] as? String {
+                    if let color = convertHEXtoUIColor(hexColor) {
+                        Wootric.setThankYouButtonBackgroundColor(color)
+                    }
+                }
+
+            case "setSocialSharingColor":
+                if let arguments = call.arguments as? [String: Any],
+                   let hexColor = arguments["color"] as? String {
+                    if let color = convertHEXtoUIColor(hexColor) {
+                        Wootric.setSocialSharing(color)
+                    }
+                }
+
             case "showWootricSurvey":
                 if let window = UIApplication.shared.delegate?.window {
                     let viewController = window?.rootViewController
@@ -120,5 +152,34 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
             default:
                 result(FlutterMethodNotImplemented)
             }
+    }
+
+    private func convertHEXtoUIColor(_ hex: String) -> UIColor? {
+      let r, g, b, a: CGFloat
+
+      if hex.hasPrefix("#") {
+        let start = hex.index(hex.startIndex, offsetBy: 1)
+        var hexColor = String(hex[start...])
+        if hexColor.count == 6 {
+          hexColor = hexColor + "FF"
+        }
+
+        if hexColor.count == 8 {
+            let scanner = Scanner(string: hexColor)
+            var hexNumber: UInt64 = 0
+
+            if scanner.scanHexInt64(&hexNumber) {
+                r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+                g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+                b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
+                a = CGFloat(hexNumber & 0x000000ff) / 255
+
+                let color = UIColor.init(red: r, green: g, blue: b, alpha: a)
+                return color
+            }
+        }
+      }
+
+      return nil
     }
 }

--- a/lib/wootricsdk_flutter.dart
+++ b/lib/wootricsdk_flutter.dart
@@ -102,6 +102,30 @@ class WootricsdkFlutter {
     WootricsdkFlutterPlatform.instance.setLanguageCode(languageCode);
   }
 
+	/// Wootric allows you to set a custom color for the survey slider.
+	/// To set a custom color pass appropriate [color] in hex format.
+	static setSliderColor(String color) {
+	  WootricsdkFlutterPlatform.instance.setSliderColor(color);
+	}
+
+	/// Wootric allows you to set a custom color for the Send button.
+	/// To set a custom color pass appropriate [color] in hex format.
+	static setSendButtonBackgroundColor(String color) {
+	  WootricsdkFlutterPlatform.instance.setSendButtonBackgroundColor(color);
+	}
+
+	/// Wootric allows you to set a custom color for the Thank You button.
+	/// To set a custom color pass appropriate [color] in hex format.
+	static setThankYouButtonBackgroundColor(String color) {
+	  WootricsdkFlutterPlatform.instance.setThankYouButtonBackgroundColor(color);
+	}
+
+	/// Wootric allows you to set a custom color for social sharing buttons.
+	/// To set a custom color pass appropriate [color] in hex format.
+	static setSocialSharingColor(String color) {
+	  WootricsdkFlutterPlatform.instance.setSocialSharingColor(color);
+	}
+
   /// Display Wootric survey driven by configured settings.
   static showSurvey() {
     WootricsdkFlutterPlatform.instance.showSurvey();

--- a/lib/wootricsdk_flutter_method_channel.dart
+++ b/lib/wootricsdk_flutter_method_channel.dart
@@ -150,6 +150,42 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
     });
   }
 
+  /// Wootric allows you to set a custom color for the survey slider.
+  /// To set a custom color pass appropriate [color] in hex format.
+  @override
+  setSliderColor(String color) {
+    methodChannel.invokeMethod('setSliderColor', {
+      'color': color,
+    });
+  }
+
+  /// Wootric allows you to set a custom color for the Send button.
+  /// To set a custom color pass appropriate [color] in hex format.
+  @override
+  setSendButtonBackgroundColor(String color) {
+    methodChannel.invokeMethod('setSendButtonBackgroundColor', {
+      'color': color,
+    });
+  }
+
+  /// Wootric allows you to set a custom color for the Thank You button.
+  /// To set a custom color pass appropriate [color] in hex format.
+  @override
+  setThankYouButtonBackgroundColor(String color) {
+    methodChannel.invokeMethod('setThankYouButtonBackgroundColor', {
+      'color': color,
+    });
+  }
+
+  /// Wootric allows you to set a custom color for social sharing buttons.
+  /// To set a custom color pass appropriate [color] in hex format.
+  @override
+  setSocialSharingColor(String color) {
+    methodChannel.invokeMethod('setSocialSharingColor', {
+      'color': color,
+    });
+  }
+
   @override
   showSurvey() {
     methodChannel.invokeMethod('showWootricSurvey');

--- a/lib/wootricsdk_flutter_platform_interface.dart
+++ b/lib/wootricsdk_flutter_platform_interface.dart
@@ -117,6 +117,31 @@ abstract class WootricsdkFlutterPlatform extends PlatformInterface {
   setLanguageCode(String languageCode) {
 
   }
+
+  /// Wootric allows you to set a custom color for the survey slider.
+  /// To set a custom color pass appropriate [color] in hex format.
+  setSliderColor(String color) {
+
+  }
+
+  /// Wootric allows you to set a custom color for the Send button.
+  /// To set a custom color pass appropriate [color] in hex format.
+  setSendButtonBackgroundColor(String color) {
+
+  }
+
+  /// Wootric allows you to set a custom color for the Thank You button.
+  /// To set a custom color pass appropriate [color] in hex format.
+  setThankYouButtonBackgroundColor(String color) {
+
+  }
+
+  /// Wootric allows you to set a custom color for social sharing buttons.
+  /// To set a custom color pass appropriate [color] in hex format.
+  setSocialSharingColor(String color) {
+
+  }
+
   /// Display Wootric survey driven by configured settings.
   showSurvey() {
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wootricsdk_flutter
 description: This is an official Wootric SDK Wrapper for Flutter. To use this plugin you need minimum a free Wootric Account with valid ClientId and AccountToken. You can visit wootric website for more details. Here is the official documentation for wootric - http://docs.wootric.com/
-version: 0.1.0
+version: 0.2.0
 homepage: https://inmoment.com/wootric/
 repository: https://github.com/Wootric/WootricSDK-flutter/
 issue_tracker: https://github.com/Wootric/WootricSDK-flutter/issues


### PR DESCRIPTION
Add color customization methods.

## Test

1. Checkout this branch
2. Create a new flutter project and add this project as a dependency in your `pubspec.yaml`:

```
dependencies:
  flutter:
    sdk: flutter
...
  wootricsdk_flutter:
    path: /Users/username/path/to/WootricSDK-flutter
```

3. Use the new methods

```dart
    WootricsdkFlutter.configure(
      clientId: "YOUR_CLIENT_ID",
      accountToken: "YOUR_ACCOUNT_TOKEN",
    );
    WootricsdkFlutter.setEndUserEmail('email@test.com');
    WootricsdkFlutter.setSliderColor("#FF0000");
    WootricsdkFlutter.setSendButtonBackgroundColor("#FF0000");
    WootricsdkFlutter.setThankYouButtonBackgroundColor("#FF0000");
    WootricsdkFlutter.setSocialSharingColor("#FF0000");
    WootricsdkFlutter.showSurvey();
  }

```

4. Test both iOS and Android