### PR TITLE
Add disclaimer support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.8] - 2024-03-20
+
+* Add support for disclaimer method
+
 ## [0.0.7] - 2023-07-12
 
 * Fix setSliderColor bug for Android in tablets (https://github.com/Wootric/WootricSDK-flutter/issues/8)

--- a/README.md
+++ b/README.md
@@ -58,3 +58,11 @@ WootricsdkFlutter.setLogLevelVerbose();
 WootricsdkFlutter.setLogLevelError();
 WootricsdkFlutter.setLogLevelNone();
 ```
+
+## showDisclaimer
+
+When `disclaimerText, link and linkText` are set, the survey will display the text and link at the bottom of the survey.
+
+```
+WootricsdkFlutter.showDisclaimer("Learn how we handle your feedback","https://example.com/terms-of-use","here");
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.wootric:wootric-sdk-android:2.25.1'
+    implementation 'com.wootric:wootric-sdk-android:2.26.1'
+
 }

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -3,6 +3,7 @@ package com.inmoment.wootricsdk_flutter
 import android.app.Activity
 import android.graphics.Color
 import androidx.annotation.NonNull
+import android.net.Uri;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
@@ -101,6 +102,12 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     } else if (call.method.equals("showWootricSurveyWithEvent")) {
       val eventName: String? = call.argument("eventName")
       wootric?.survey(eventName)
+    } else if (call.method.equals("showDisclaimer")) {
+      val disclaimerText: String? = call.argument("disclaimerText")
+      val disclaimerLink: String? = call.argument("disclaimerLinkURL")
+      val disclaimerLinkText: String? = call.argument("disclaimerLinkText")
+      val disclaimerLinkURI = Uri.parse(disclaimerLink)
+      wootric?.showDisclaimer(disclaimerText, disclaimerLinkURI, disclaimerLinkText)
     } else {
       result.notImplemented()
     }

--- a/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
+++ b/ios/Classes/SwiftWootricsdkFlutterPlugin.swift
@@ -134,6 +134,15 @@ public class SwiftWootricsdkFlutterPlugin: NSObject, FlutterPlugin {
                     }
                 }
 
+            case "showDisclaimer":
+                if let arguments = call.arguments as? [String: Any] {
+                    let disclaimerText = arguments["disclaimerText"] as? String
+                    let disclaimerLink = arguments["disclaimerLinkURL"] as? String
+                    let disclaimerLinkText = arguments["disclaimerLinkText"] as? String
+                    let disclaimerLinkURL = URL(string: disclaimerLink!)
+                    Wootric.showDisclaimerText(disclaimerText, link: disclaimerLinkURL, linkText: disclaimerLinkText)
+                }
+
             case "showWootricSurvey":
                 if let window = UIApplication.shared.delegate?.window {
                     let viewController = window?.rootViewController

--- a/ios/wootricsdk_flutter.podspec
+++ b/ios/wootricsdk_flutter.podspec
@@ -15,7 +15,7 @@ A new Flutter plugin project.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'WootricSDK', '0.25.0'
+  s.dependency 'WootricSDK', '0.27.0'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/wootricsdk_flutter.dart
+++ b/lib/wootricsdk_flutter.dart
@@ -132,6 +132,12 @@ class WootricsdkFlutter {
     WootricsdkFlutterPlatform.instance.setSocialSharingColor(color);
   }
 
+  /// Wootric allows you to set a disclaimer text with a link
+  /// To set a disclaimer text pass disclaimerText, a disclaimerLinkURL and a disclaimerLinkText
+  static showDisclaimer(String disclaimerText, String disclaimerLinkURL, String disclaimerLinkText) {
+    WootricsdkFlutterPlatform.instance.showDisclaimer(disclaimerText, disclaimerLinkURL, disclaimerLinkText);
+  }
+
   /// Display Wootric survey driven by configured settings.
   static showSurvey() {
     WootricsdkFlutterPlatform.instance.showSurvey();

--- a/lib/wootricsdk_flutter_method_channel.dart
+++ b/lib/wootricsdk_flutter_method_channel.dart
@@ -186,6 +186,17 @@ class MethodChannelWootricsdkFlutter extends WootricsdkFlutterPlatform {
     });
   }
 
+  /// Wootric allows you to set a disclaimer text with a link
+  /// To set a disclaimer text pass disclaimerText, a disclaimerLinkURL and a disclaimerLinkText
+  @override
+  showDisclaimer(String disclaimerText, String disclaimerLinkURL, String disclaimerLinkText) {
+    methodChannel.invokeMethod('showDisclaimer', {
+      'disclaimerText': disclaimerText,
+      'disclaimerLinkURL': disclaimerLinkURL,
+      'disclaimerLinkText': disclaimerLinkText
+    });
+  }
+
   @override
   showSurvey() {
     methodChannel.invokeMethod('showWootricSurvey');

--- a/lib/wootricsdk_flutter_platform_interface.dart
+++ b/lib/wootricsdk_flutter_platform_interface.dart
@@ -105,6 +105,10 @@ abstract class WootricsdkFlutterPlatform extends PlatformInterface {
   /// To set a custom color pass appropriate [color] in hex format.
   setSocialSharingColor(String color) {}
 
+  /// Wootric allows you to set a disclaimer text with a link
+  /// To set a disclaimer text pass disclaimerText, a disclaimerLinkURL and a disclaimerLinkText
+  showDisclaimer(String disclaimerText, String disclaimerLinkURL, String disclaimerLinkText) {}
+
   /// Display Wootric survey driven by configured settings.
   showSurvey() {}
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wootricsdk_flutter
 description: This is an official Wootric SDK Wrapper for Flutter. You can visit wootric website for more details. Here is the official documentation for wootric - http://docs.wootric.com/
-version: 0.0.7
+version: 0.0.8
 homepage: https://inmoment.com/wootric/
 repository: https://github.com/Wootric/WootricSDK-flutter/
 issue_tracker: https://github.com/Wootric/WootricSDK-flutter/issues


### PR DESCRIPTION
Add support to show disclaimer text with link at the bottom of the survey.

## Test

1. Checkout this branch
2. Create a new flutter project and add this project as a dependency in your `pubspec.yaml`:

```
dependencies:
  flutter:
    sdk: flutter
...
  wootricsdk_flutter:
    path: /Users/username/path/to/WootricSDK-flutter
```

3. Configure `WootricsdkFlutter`:

```dart
    WootricsdkFlutter.configure(
      clientId: "YOUR_CLIENT_ID",
      accountToken: "YOUR_ACCOUNT_TOKEN",
    );
    WootricsdkFlutter.setEndUserEmail('email@test.com');
    WootricsdkFlutter.showDisclaimer("Learn how we handle your feedback","https://inmoment.com/terms-of-use/","here");
    WootricsdkFlutter.showSurvey();
  }

```

4. Test both iOS and Android