### PR TITLE
Fix Android Int to Long cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.9] - 2024-06-04
+
+* Fix `Int` to `Long` cast in Android `setEndUserCreatedAt`
+
 ## [0.0.8] - 2024-03-20
 
 * Add support for disclaimer method

--- a/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/inmoment/wootricsdk_flutter/WootricsdkFlutterPlugin.kt
@@ -54,9 +54,9 @@ class WootricsdkFlutterPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       val value = forceSurvey ?: false
       wootric?.setSurveyImmediately(value)
     } else if (call.method.equals("setEndUserCreatedAt")) {
-      val endUserCreatedAt: Long? = call.argument("endUserCreatedAt")
+      val endUserCreatedAt: Int? = call.argument("endUserCreatedAt")
       if (endUserCreatedAt != null) {
-        wootric?.setEndUserCreatedAt(endUserCreatedAt)
+        wootric?.setEndUserCreatedAt(endUserCreatedAt.toLong())
       }
     } else if (call.method.equals("setFirstSurveyAfter")) {
       val numberOfDays: Int? = call.argument("numberOfDays")

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wootricsdk_flutter
 description: This is an official Wootric SDK Wrapper for Flutter. You can visit wootric website for more details. Here is the official documentation for wootric - http://docs.wootric.com/
-version: 0.0.8
+version: 0.0.9
 homepage: https://inmoment.com/wootric/
 repository: https://github.com/Wootric/WootricSDK-flutter/
 issue_tracker: https://github.com/Wootric/WootricSDK-flutter/issues
@@ -21,7 +21,6 @@ dev_dependencies:
   flutter_lints: ^2.0.0
 
 flutter:
-
   plugin:
     platforms:
       android:


### PR DESCRIPTION

There is a Crash on Android `setEndUserCreatedAt` : 

```dart
flutter_error_exception | PlatformException(error, java.lang.Integer cannot be cast to java.lang.Long, null, java.lang.ClassCastException:
```

The cause is that `WootricsdkFlutter` expects an `int` for `setEndUserCreatedAt` and the Android Plugin file expects a `Long`. 
 
This pull request fix this by expecting a `Int` and converting to `Long` as it uses. 
