### PR TITLE
Moves android namespace declaration from AndroidManifest to build.gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.0.10] - 2025-04-03
+
+* Moves android namespace declaration from `AndroidManifest.xml` to `build.gradle`
+
 ## [0.0.9] - 2024-06-04
 
 * Fix `Int` to `Long` cast in Android `setEndUserCreatedAt`

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,8 @@ apply plugin: 'kotlin-android'
 android {
     compileSdkVersion 31
 
+    namespace = "com.inmoment.wootricsdk_flutter"
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.inmoment.wootricsdk_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wootricsdk_flutter
 description: This is an official Wootric SDK Wrapper for Flutter. You can visit wootric website for more details. Here is the official documentation for wootric - http://docs.wootric.com/
-version: 0.0.9
+version: 0.0.10
 homepage: https://inmoment.com/wootric/
 repository: https://github.com/Wootric/WootricSDK-flutter/
 issue_tracker: https://github.com/Wootric/WootricSDK-flutter/issues


### PR DESCRIPTION
Android Gradle Plugin requires namespace to be declared on build.gradle instead of AndroidManifest.xml since 8.0:
https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl